### PR TITLE
Better attribute management, CDataKeys(), writeRaw(), typo fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [PHP] Array to XML
 ============
 
-Array2xml is a PHP library that convers array to valid XML.
+Array2xml is a PHP library that converts array to valid XML.
 
 Based on [XMLWriter](http://php.net/manual/en/book.xmlwriter.php).
 
@@ -15,21 +15,21 @@ Installation
 Usage (Ex.: RSS Last News)
 ----------------
 
-Load the library and set custom configuration
+Load the library and set custom configuration:
 
 	$array2xml = new Array2xml();
 	$array2xml->setRootName('rss');
 	$array2xml->setRootAttrs(array('version' => '2.0'));
-	$array2xml->setCDataKeys(array('description' => TRUE));
+	$array2xml->setCDataKeys(array('description'));
 
-Start to create first root elements
+Start by creating a root element:
 
 	$data['channel']['title'] 		= 'News RSS';
 	$data['channel']['link'] 		= 'http://yoursite.com/';
 	$data['channel']['description'] = 'Amazing RSS News';
 	$data['channel']['language']	= 'en';
 
-Now, pass elements from DB query in cycle
+Now pass elements from DB query in cycle:
 
 	$row = $db->lastNews();
 	foreach($row as $key => $lastNews)
@@ -40,7 +40,21 @@ Now, pass elements from DB query in cycle
 		$data['channel'][$key]['item']['pubDate'] 		= date(DATE_RFC1123, strtotime($lastNews->added));
 	}
 
-And finally, convert and print output data to screen
+You can also set element attributes individually like this:
+	
+	$data['channel'][$key]['item']['@attributes'] 		= array('AttributeName' => $attributeValue);
+	
+Alternatively, you can use setElementAttrs() method:
+
+	$array2xml->setElementAttrs( array('ElementName' => array('AttributeName' => $attributeValue) ));
+
+Note that in this case all elements with specified name will have identical attribute names and values.
+
+If you need to include a raw XML tree somewhere, mark it's element using `$array2xml->setRawKeys(array('elementName'))`
+
+
+
+Finally, convert and print output data to screen
 
 	echo $array2xml->convert($data);
 	exit;

--- a/array2xml.php
+++ b/array2xml.php
@@ -17,7 +17,7 @@ class Array2xml
 	private $rootName = 'root';
 	private $rootAttrs = array();        //example: array('first_attr' => 'value_of_first_attr', 'second_atrr' => 'etc');
 	private $rootSelf = FALSE;
-	private $emelentsAttrs = array();        //example: $attrs['element_name'][] = array('attr_name' => 'attr_value');
+	private $elementAttrs = array();        //example: $attrs['element_name'][] = array('attr_name' => 'attr_value');
 	private $CDataKeys = array();
 	private $newLine = "\n";
 	private $newTab = "\t";
@@ -25,6 +25,7 @@ class Array2xml
 	private $skipNumeric = TRUE;
 	private $_tabulation = TRUE;            //TODO
     private $defaultTagName = FALSE;    //Tag For Numeric Array Keys
+	private $rawKeys = array();
 
 	/**
 	 * Constructor
@@ -181,9 +182,23 @@ class Array2xml
 	 * @param    array
 	 * @return    void
 	 */
-	public function setCDataKeys($CDataKeys)
+	public function setCDataKeys(array $CDataKeys)
 	{
-		$this->CDataKeys = (array)$CDataKeys;
+		$this->CDataKeys = $CDataKeys;
+	}
+
+	// --------------------------------------------------------------------
+
+	/**
+	 * Set keys of array that needed to be as Raw XML in XML document
+	 *
+	 * @access    public
+	 * @param     array
+	 * @return    void
+	 */
+	public function setRawKeys(array $rawKeys)
+	{
+		$this->rawKeys = $rawKeys;
 	}
 
 	// --------------------------------------------------------------------
@@ -271,6 +286,7 @@ class Array2xml
 		foreach ($data as $key => $val)
 		{
             unset($data[$key]);
+			if(substr($key, 0,1) == '@') continue;
 			if (is_numeric($key) && $this->defaultTagName !== FALSE)
             {
                 $key = $this->defaultTagName;
@@ -307,10 +323,16 @@ class Array2xml
 				$this->writer->startElement($key);
 
 				// Check if there are some attributes
-				if (isset($this->emelentsAttrs[$key]))
+				if (isset($this->elementAttrs[$key]) || isset($val['@attributes']))
 				{
+					if(isset($val['@attributes']) && is_array($val['@attributes'])){
+						$attributes = $val['@attributes'];
+					}else{
+						$attributes = $this->elementAttrs[$key];
+					}
+
 					// Yeah, lets add them
-					foreach ($this->emelentsAttrs[$key] as $elementAttrName => $elementAttrText)
+					foreach ($attributes as $elementAttrName => $elementAttrText)
 					{
 						$this->writer->startAttribute($elementAttrName);
 						$this->writer->text($elementAttrText);

--- a/array2xml.php
+++ b/array2xml.php
@@ -365,6 +365,9 @@ class Array2xml
 					{
 						$this->writer->writeCData($val);
 					}
+					elseif(isset($this->rawKeys[$key])){
+						$this->writer->writeRaw($val);
+					}
 					else
 					{
 						$this->writer->text($val);


### PR DESCRIPTION
This PR closes issues #5 and #6 and also provides a new way to manage element attributes which allows you to set attribute names and values to the element individually.

For example, the following code sets an attribute to particular `item` element.

`$data['channel']['someChannel']['item']['@attributes'] = array('AttrName' => $attrValue);`

This is useful when you have multiple datasets with variable attributes.

The old way is also supported so there are no BC breaks.