### PR TITLE
Added setEmptyElementSyntax(), setFilterNumbersInTags(), skipNumeric() fix + tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.xcuserstate
+.idea

--- a/README.md
+++ b/README.md
@@ -79,26 +79,26 @@ Configuration
 
 You can easily configure this lib to fit your specific use case using setters described below.
 
-### setVersion(string $version)
+#### setVersion(string $version)
 Sets XML version header.
-### setEncoding(string $encoding)
+#### setEncoding(string $encoding)
 Sets XML encoding
-### setRootName(string $rootName)
+#### setRootName(string $rootName)
 Set XML Root Element Name 
-### setRootAttrs(array $rootAttrs)
+#### setRootAttrs(array $rootAttrs)
 Set XML Root Element Attributes
-### setElementsAttrs(array $attrs)
+#### setElementsAttrs(array $attrs)
 Set Attributes of every XML Elements that matches the given names.
 Example argument: `['elementName' => ['someAttr' => 'attrValue']]`
-### setCDataKeys(array $elementNames)
+#### setCDataKeys(array $elementNames)
 Marking given elements as CData ones
-### setRawKeys(array $elementNames)
+#### setRawKeys(array $elementNames)
 Marking given elements as raw ones
-### setNumericTagPrefix(string $prefix)
+#### setNumericTagPrefix(string $prefix)
 Set default prefix for numeric nodes
-### setSkipNumeric(bool $skipNumeric)
+#### setSkipNumeric(bool $skipNumeric)
 On/Off Skip numeric nodes
-### setEmptyElementSyntax(const)
+#### setEmptyElementSyntax(const)
 In some cases you might want to control the exact syntax of empty elements.
 
 By default, nodes that are empty or equal to null are using self-closing syntax(`<foo/>`).
@@ -107,7 +107,7 @@ You can override this behavior using `Array2xml::EMPTY_FULL` to force using clos
 
 Available agruments are `Array2xml::EMPTY_SELF_CLOSING` or `Array2xml::EMPTY_FULL`
 
-### setFilterNumbersInTags(bool|array $data)
+#### setFilterNumbersInTags(bool|array $data)
 Remove numbers from element names.
 
 Possible args are: 

--- a/README.md
+++ b/README.md
@@ -6,10 +6,16 @@ Array2xml is a PHP library that converts array to valid XML.
 Based on [XMLWriter](http://php.net/manual/en/book.xmlwriter.php).
 
 
+Requirements
+------------
+
+* PHP 5.3+
+* XMLWriter
+
 Installation
 ------------
 
-	require ('/path/to/libs/array2xml.php');
+	require_once ('/path/to/array2xml.php');
 
 
 Usage (Ex.: RSS Last News)
@@ -24,31 +30,41 @@ Load the library and set custom configuration:
 
 Start by creating a root element:
 
-	$data['channel']['title'] 		= 'News RSS';
-	$data['channel']['link'] 		= 'http://yoursite.com/';
-	$data['channel']['description'] = 'Amazing RSS News';
-	$data['channel']['language']	= 'en';
+	$data['channel']['title']        = 'News RSS';
+	$data['channel']['link']         = 'http://yoursite.com/';
+	$data['channel']['description']  = 'Amazing RSS News';
+	$data['channel']['language']     = 'en';
 
 Now pass elements from DB query in cycle:
 
 	$row = $db->lastNews();
 	foreach($row as $key => $lastNews)
 	{
-		$data['channel'][$key]['item']['title'] 		= $lastNews->title;
-		$data['channel'][$key]['item']['link'] 			= 'http://yoursite.com/news/'.$lastNews->url;
-		$data['channel'][$key]['item']['description'] 	= $lastNews->description;
-		$data['channel'][$key]['item']['pubDate'] 		= date(DATE_RFC1123, strtotime($lastNews->added));
+		$data['channel'][$key]['item']['title']       = $lastNews->title;
+		$data['channel'][$key]['item']['link']        = 'http://yoursite.com/news/'.$lastNews->url;
+		$data['channel'][$key]['item']['description'] = $lastNews->description;
+		$data['channel'][$key]['item']['pubDate']     = date(DATE_RFC1123, strtotime($lastNews->added));
 	}
 
-You can also set element attributes individually like this:
+You can also set element attributes individually. 
+The example below appends an attribute `AttributeName` to `item` node:
 	
 	$data['channel'][$key]['item']['@attributes'] 		= array('AttributeName' => $attributeValue);
 	
-Alternatively, you can use setElementAttrs() method:
+Or, if your node doesn't have children, you can use this:
+    
+    $data['channel]['@attributes'] = array('AttributeName' => $attributeValue);
+    $data['channel]['@content']    = 'Content of channel node';
+    
+This will set both attributes and the content of `channel` node.
+	
+	
+	
+Alternatively, you can use setElementsAttrs() method:
 
-	$array2xml->setElementAttrs( array('ElementName' => array('AttributeName' => $attributeValue) ));
+	$array2xml->setElementsAttrs( array('ElementName' => array('AttributeName' => $attributeValue) ));
 
-Note that in this case all elements with specified name will have identical attribute names and values.
+*Note that in this case all elements with specified names will have identical attribute names and values.*
 
 If you need to include a raw XML tree somewhere, mark it's element using `$array2xml->setRawKeys(array('elementName'))`
 
@@ -57,4 +73,66 @@ If you need to include a raw XML tree somewhere, mark it's element using `$array
 Finally, convert and print output data to screen
 
 	echo $array2xml->convert($data);
-	exit;
+	
+Configuration
+----------------
+
+You can easily configure this lib to fit your specific use case using setters described below.
+
+### setVersion(string $version)
+Sets XML version header.
+### setEncoding(string $encoding)
+Sets XML encoding
+### setRootName(string $rootName)
+Set XML Root Element Name 
+### setRootAttrs(array $rootAttrs)
+Set XML Root Element Attributes
+### setElementsAttrs(array $attrs)
+Set Attributes of every XML Elements that matches the given names.
+Example argument: `['elementName' => ['someAttr' => 'attrValue']]`
+### setCDataKeys(array $elementNames)
+Marking given elements as CData ones
+### setRawKeys(array $elementNames)
+Marking given elements as raw ones
+### setNumericTagPrefix(string $prefix)
+Set default prefix for numeric nodes
+### setSkipNumeric(bool $skipNumeric)
+On/Off Skip numeric nodes
+### setEmptyElementSyntax(const)
+In some cases you might want to control the exact syntax of empty elements.
+
+By default, nodes that are empty or equal to null are using self-closing syntax(`<foo/>`).
+
+You can override this behavior using `Array2xml::EMPTY_FULL` to force using closing tag(`<foo></foo>`).
+
+Available agruments are `Array2xml::EMPTY_SELF_CLOSING` or `Array2xml::EMPTY_FULL`
+
+### setFilterNumbersInTags(bool|array $data)
+Remove numbers from element names.
+
+Possible args are: 
+
+- `boolean TRUE` to remove numbers from ALL elements
+- `array` contains node names that need filtering.
+
+This is a easy workaround to have identically named elements in your XML built from an array.
+
+For example, let's build an XML with 3 `image` nodes:
+
+    //list of our images
+    $images = array('image1.jpg', 'image3.jpg', 'image3.jpg');
+    // input array
+    $data = array(); 
+    for($i=0;$i<3;$i++){
+    	$data['image'.$i] = $images[$i];
+    }
+    $array2xml = new array2xml();
+    $array2xml->setFilterNumbersInTags(array('image'));
+    
+    $xml = array2xml->convert($data);
+    
+That's it! Now we have a nasty XML with 3 identically named nodes in it.
+
+Testing
+----------------
+    phpunit Tests/Array2xmlTest.php

--- a/Tests/Array2xmlTest.php
+++ b/Tests/Array2xmlTest.php
@@ -1,0 +1,287 @@
+<?php
+require_once '../array2xml.php';
+
+class Array2xmlTest extends PHPUnit_Framework_TestCase {
+
+    /**
+     * @var Array2xml
+     */
+    protected $array2xml;
+
+    protected function setUp(){
+        $this->array2xml = new Array2xml();
+        $this->array2xml->setNewTab("\t\t");
+    }
+
+    protected function tearDown(){
+        $this->array2xml = null;
+    }
+
+    protected function execute($expected_xml, $actual_array){
+
+        $actual_xml = $this->array2xml->convert($actual_array);
+
+        $actual = new DOMDocument;
+        $actual->preserveWhiteSpace = false;
+        $actual->loadXML($actual_xml);
+
+        $expected = new DOMDocument;
+        $expected->preserveWhiteSpace = false;
+        $expected->loadXML($expected_xml);
+
+        $this->assertEqualXMLStructure(
+            $expected->firstChild, $actual->firstChild, true
+        );
+        $this->assertEquals($expected, $actual);
+    }
+
+    public function testConvertDefault(){
+
+        $actual = array(
+            'item1' => 'Text 3',
+            'item2' => 1234,
+            'item3' => array(
+                'subItem1' => 'Text 1',
+                'subItem2' => 'Text 2'
+            ),
+        );
+
+        $expected = '<root>
+<item1>Text 3</item1>
+<item2>1234</item2>
+<item3>
+        <subItem1>Text 1</subItem1>
+        <subItem2>Text 2</subItem2>
+</item3>
+</root>';
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testSkipNumeric(){
+        $actual = array(
+            '1234' => 'Text 3',
+            'item2' => 1234,
+            'item3' => array(
+                'subItem1' => 'Text 1',
+                'subItem2' => 'Text 2'
+            ),
+        );
+
+        $expected = '<root>
+<item2>1234</item2>
+<item3>
+        <subItem1>Text 1</subItem1>
+        <subItem2>Text 2</subItem2>
+</item3>
+</root>';
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testNoSkipNumeric(){
+        $actual = array(
+            '1234' => 'Text 3',
+            'item2' => 1234,
+            'item3' => array(
+                'subItem1' => 'Text 1',
+                'subItem2' => 'Text 2'
+            ),
+        );
+
+        $expected = '<root>
+<key1234>Text 3</key1234>
+<item2>1234</item2>
+<item3>
+        <subItem1>Text 1</subItem1>
+        <subItem2>Text 2</subItem2>
+</item3>
+</root>';
+
+        $this->array2xml->setSkipNumeric(FALSE);
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testFilterNumbersAll(){
+        $actual = array(
+            'item1' => 'Text 3',
+            'item2' => 1234,
+            'item3' => array(
+                'subItem1' => 'Text 1',
+                'subItem2' => 'Text 2'
+            ),
+        );
+
+        $expected = '<root>
+<item>Text 3</item>
+<item>1234</item>
+<item>
+        <subItem>Text 1</subItem>
+        <subItem>Text 2</subItem>
+</item>
+</root>';
+
+        $this->array2xml->setFilterNumbersInTags(TRUE);
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testFilterNumbersSpecific(){
+        $actual = array(
+            'foo1' => 'Text 3',
+            'bar1' => 1234,
+            'baz1' => array(
+                'subBaz1'   => 'Text 1',
+                'subBaz2'   => 'Text 1',
+                'subBaz3'   => 'Text 1',
+                'subBaz4'   => 'Text 1',
+                'subItem2' => 'Text 2'
+            ),
+        );
+
+        $expected = '<root>
+<foo>Text 3</foo>
+<bar1>1234</bar1>
+<baz1>
+        <subBaz>Text 1</subBaz>
+        <subBaz>Text 1</subBaz>
+        <subBaz>Text 1</subBaz>
+        <subBaz>Text 1</subBaz>
+        <subItem2>Text 2</subItem2>
+</baz1>
+</root>';
+
+        $this->array2xml->setFilterNumbersInTags(array('foo','subBaz'));
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testEmptyElementSyntaxFull(){
+        $actual = array('foo' => '', 'bar' => 'text');
+        $expected = '<root><foo></foo><bar>text</bar></root>';
+
+        $this->array2xml->setEmptyElementSyntax(Array2xml::EMPTY_FULL);
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testConvertEmptyElementSyntaxSelf(){
+        $actual = array('foo' => '', 'bar' => 'text');
+        $expected = '<root><foo/><bar>text</bar></root>';
+
+        $this->array2xml->setEmptyElementSyntax(Array2xml::EMPTY_SELF_CLOSING);
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testElementAttrsDefault(){
+        $actual = array('foo' => 'Some', 'bar' => 'Text');
+        $expected = '<root><foo test="true">Some</foo><bar>Text</bar></root>';
+
+        $this->array2xml->setElementsAttrs(array('foo' => array('test' => 'true')));
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testElementAttrsDynamic(){
+        $actual = array(
+            'foo' => array('@content' => 'Some', '@attributes' => array('test' => 'true')),
+            'bar' => 'Text'
+        );
+        $expected = '<root><foo test="true">Some</foo><bar>Text</bar></root>';
+
+        $this->execute($expected, $actual);
+    }
+
+    public function testRootAttrs(){
+
+        $actual = array('foo' => 'text');
+        $expected = '<root someAttr="value" someOtherAttr="some value"><foo>text</foo></root>';
+
+        $this->array2xml->setRootAttrs(array('someAttr'=>'value', 'someOtherAttr' => 'some value'));
+
+        $this->execute($expected,$actual);
+    }
+
+    public function testRootName(){
+        $actual = array('foo' => 'text');
+        $expected = '<products><foo>text</foo></products>';
+
+        $this->array2xml->setRootName('products');
+
+        $this->execute($expected,$actual);
+    }
+
+    public function testNonAssocArrayDefault(){
+        $actual = array(1,5,2,'some', null);
+
+        $expected1_xml = '<root></root>';
+
+        $actual_xml = $this->array2xml->convert($actual);
+
+        $actual = new DOMDocument;
+        $actual->preserveWhiteSpace = false;
+        $actual->loadXML($actual_xml);
+
+        $expected1 = new DOMDocument;
+        $expected1->preserveWhiteSpace = false;
+        $expected1->loadXML($expected1_xml);
+
+        $this->assertEqualXMLStructure(
+            $expected1->firstChild, $actual->firstChild, true
+        );
+    }
+
+    public function testNonAssocArrayConfigured(){
+
+        $actual = array(1,5,2,'some', null);
+        $expected_xml = '<root>
+<key0>1</key0>
+<key1>5</key1>
+<key2>2</key2>
+<key3>some</key3>
+<key4></key4>
+</root>';
+
+        $this->array2xml->setEmptyElementSyntax(Array2xml::EMPTY_FULL);
+        $this->array2xml->setSkipNumeric(FALSE);
+
+        $this->execute($expected_xml, $actual);
+    }
+
+    public function testCyrillic(){
+        $actual = array('itemOne'=>'Один', 'itemTwo' => 'Демо строка');
+        $expected_xml = '<root><itemOne>Один</itemOne><itemTwo>Демо строка</itemTwo></root>';
+
+        $this->execute($expected_xml, $actual);
+    }
+
+    public function testInvalidAttributesDynamic(){
+        $actual = array(
+            'foo' => array('@content' => 'Some'),
+            'bar' => 'Text'
+        );
+
+        $expected_xml = '<root><foo></foo><bar>Text</bar></root>';
+
+        $actual_xml = $this->array2xml->convert($actual);
+
+        $actual = new DOMDocument;
+        $actual->preserveWhiteSpace = false;
+        $actual->loadXML($actual_xml);
+
+        $expected = new DOMDocument;
+        $expected->preserveWhiteSpace = false;
+        $expected->loadXML($expected_xml);
+
+        $this->assertEqualXMLStructure(
+            $expected->firstChild, $actual->firstChild, true
+        );
+    }
+
+
+
+
+
+}

--- a/array2xml.php
+++ b/array2xml.php
@@ -32,8 +32,8 @@ class Array2xml
 
 
 
-	const EMPTY_SELF_CLOSING	= 1;
-	const EMPTY_FULL			= 2;
+	const EMPTY_SELF_CLOSING    = 1;
+	const EMPTY_FULL            = 2;
 
 
 	/**

--- a/array2xml.php
+++ b/array2xml.php
@@ -375,7 +375,8 @@ class Array2xml
 				}
 			}
 
-			if($this->filterNumbers === TRUE || in_array(preg_replace('#[0-9]*#', '', $key), $this->tagsToFilter))
+			if($this->filterNumbers === TRUE
+				|| in_array(preg_replace('#[0-9]*#', '', $key), $this->tagsToFilter))
 			{
 				//remove numbers
 				$key = preg_replace('#[0-9]*#', '', $key);
@@ -411,7 +412,11 @@ class Array2xml
 						$this->writer->endAttribute();
 					}
 
-					if(!empty($val['@content']) && is_string($val['@content']) && isset($val['@attributes']))
+					if(
+						!empty($val['@content'])
+						&& is_string($val['@content'])
+						&& isset($val['@attributes'])
+					)
 					{
 						$val = $val['@content'];
 					}
@@ -439,7 +444,8 @@ class Array2xml
 			{
 				if ($val != NULL || $val === 0)
 				{
-					if (isset($this->CDataKeys[$key]) || array_search($key, $this->CDataKeys) !== FALSE)
+					if (isset($this->CDataKeys[$key])
+						|| array_search($key, $this->CDataKeys) !== FALSE)
 					{
 						$this->writer->writeCData($val);
 					}

--- a/array2xml.php
+++ b/array2xml.php
@@ -30,8 +30,6 @@ class Array2xml
 	private $filterNumbers = FALSE;
 	private $tagsToFilter = array();
 
-
-
 	const EMPTY_SELF_CLOSING    = 1;
 	const EMPTY_FULL            = 2;
 
@@ -70,7 +68,7 @@ class Array2xml
 	 * @param    array
 	 * @return    string
 	 */
-	public function convert($data = array())
+	public function convert(array $data)
 	{
 		$this->writer->openMemory();
 		$this->writer->startDocument($this->version, $this->encoding);
@@ -369,7 +367,7 @@ class Array2xml
 						}
 					}
 
-					$key = FALSE;
+					continue;
 				}
 				else
 				{
@@ -395,9 +393,12 @@ class Array2xml
 				// Check if there are some attributes
 				if (isset($this->elementAttrs[$key]) || isset($val['@attributes']))
 				{
-					if(isset($val['@attributes']) && is_array($val['@attributes'])){
+					if(isset($val['@attributes']) && is_array($val['@attributes']))
+					{
 						$attributes = $val['@attributes'];
-					}else{
+					}
+					else
+					{
 						$attributes = $this->elementAttrs[$key];
 					}
 
@@ -408,6 +409,11 @@ class Array2xml
 						$this->writer->startAttribute($elementAttrName);
 						$this->writer->text($elementAttrText);
 						$this->writer->endAttribute();
+					}
+
+					if(!empty($val['@content']) && is_string($val['@content']) && isset($val['@attributes']))
+					{
+						$val = $val['@content'];
 					}
 
 				}


### PR DESCRIPTION
With this PR this lib is able to cover every possible use case.
In addition to some minor refactoring(mostly method names fix) i've updated README and made some unit tests. The coverage isn't perfect but will suffice for now.

Fixes
----------------
#### `@attributes` fix, introduced `@content`
Previously, this approach worked only if the node has >1 child. Now it's possible to apply dynamic attributes to childless nodes like this:
    
    $data['channel]['@attributes'] = array('AttributeName' => $attributeValue);
    $data['channel]['@content']    = 'Content of channel node';
    
This will set both attributes and the content of `channel` node.

#### `setNumericElement()` renamed to `setNumericTagPrefix()`
To reflect it's purpose clearly.
#### `setSkipNumeric()` fix
Up untill this point the produced XML was invalid when `setSkipNumeric()` is set to `TRUE`.

New features
----------------
#### setEmptyElementSyntax(const)
In some cases you might want to control the exact syntax of empty elements.

By default, nodes that are empty or equal to null are using self-closing syntax(`<foo/>`).

You can override this behavior using `Array2xml::EMPTY_FULL` to force using closing tag(`<foo></foo>`).

Available agruments are `Array2xml::EMPTY_SELF_CLOSING` or `Array2xml::EMPTY_FULL`


#### setFilterNumbersInTags(bool|array $data)
Remove numbers from element names.

Possible args are: 

- `boolean TRUE` to remove numbers from ALL elements
- `array` contains node names that need filtering.

This is a easy workaround to have identically named elements in your XML built from an array.

For example, let's build an XML with 3 `image` nodes:

    //list of our images
    $images = array('image1.jpg', 'image3.jpg', 'image3.jpg');

    // input array
    $data = array(); 

    for($i=0;$i<3;$i++){
    	$data['image'.$i] = $images[$i];
    }

    $array2xml = new array2xml();
    $array2xml->setFilterNumbersInTags(array('image'));
    
    $xml = array2xml->convert($data);
    
That's it! Now we have a nasty XML with 3 identically named nodes in it.

Testing
----------------
    phpunit Tests/Array2xmlTest.php

What's you think, @Jeckerson ?