### PR TITLE
Allow zero strings to be used with content attribute

### DIFF
--- a/Tests/Array2xmlTest.php
+++ b/Tests/Array2xmlTest.php
@@ -194,6 +194,16 @@ class Array2xmlTest extends PHPUnit_Framework_TestCase {
         $this->execute($expected, $actual);
     }
 
+    public function testElementAttrsDynamicZeroContent(){
+        $actual = array(
+            'foo' => array('@content' => '0', '@attributes' => array('test' => 'true')),
+            'bar' => 'Text'
+        );
+        $expected = '<root><foo test="true">0</foo><bar>Text</bar></root>';
+
+        $this->execute($expected, $actual);
+    }
+
     public function testRootAttrs(){
 
         $actual = array('foo' => 'text');

--- a/array2xml.php
+++ b/array2xml.php
@@ -404,7 +404,7 @@ class Array2xml
 						$this->writer->endAttribute();
 					}
 
-					if ( ! empty($val['@content']) && is_string($val['@content']) && isset($val['@attributes']))
+					if ( isset($val['@content']) && is_string($val['@content']) && isset($val['@attributes']))
 					{
 						$val = $val['@content'];
 					}


### PR DESCRIPTION
Previous implementation left out zero strings and the result in xml was empty string instead of '0'.